### PR TITLE
Pia 1417 pay button

### DIFF
--- a/GiniPayBusiness/Classes/Core/PaymentReview.storyboard
+++ b/GiniPayBusiness/Classes/Core/PaymentReview.storyboard
@@ -37,6 +37,7 @@
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <textInputTraits key="textInputTraits" keyboardType="alphabet"/>
                                                         <connections>
+                                                            <action selector="textFieldChanged:" destination="QI6-9C-Fdg" eventType="editingChanged" id="9Jd-yx-Mrd"/>
                                                             <outlet property="delegate" destination="QI6-9C-Fdg" id="0iu-pw-xsY"/>
                                                         </connections>
                                                     </textField>
@@ -66,6 +67,7 @@
                                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                                 <connections>
+                                                                    <action selector="textFieldChanged:" destination="QI6-9C-Fdg" eventType="editingChanged" id="aeK-1h-LVL"/>
                                                                     <outlet property="delegate" destination="QI6-9C-Fdg" id="m7I-0l-hOv"/>
                                                                 </connections>
                                                             </textField>
@@ -79,6 +81,7 @@
                                                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                                 <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                                                                 <connections>
+                                                                    <action selector="textFieldChanged:" destination="QI6-9C-Fdg" eventType="editingChanged" id="9nT-5u-bfz"/>
                                                                     <outlet property="delegate" destination="QI6-9C-Fdg" id="WY5-0t-Qu7"/>
                                                                 </connections>
                                                             </textField>
@@ -132,6 +135,7 @@
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <textInputTraits key="textInputTraits" keyboardType="alphabet"/>
                                                         <connections>
+                                                            <action selector="textFieldChanged:" destination="QI6-9C-Fdg" eventType="editingChanged" id="e77-jX-ySK"/>
                                                             <outlet property="delegate" destination="QI6-9C-Fdg" id="Ycx-5r-Ckx"/>
                                                         </connections>
                                                     </textField>

--- a/GiniPayBusiness/Classes/Core/PaymentReviewViewController.swift
+++ b/GiniPayBusiness/Classes/Core/PaymentReviewViewController.swift
@@ -174,7 +174,7 @@ public final class PaymentReviewViewController: UIViewController, UIGestureRecog
 
     fileprivate func configurePayButton() {
         payButton.defaultBackgroundColor = UIColor.from(giniColor: giniPayBusinessConfiguration.payButtonBackgroundColor)
-        payButton.disabledBackgroundColor = .gray
+        payButton.disabledBackgroundColor = .lightGray
         payButton.layer.cornerRadius = giniPayBusinessConfiguration.payButtonCornerRadius
         payButton.titleLabel?.font = giniPayBusinessConfiguration.customFont.regular
         payButton.tintColor = UIColor.from(giniColor: giniPayBusinessConfiguration.payButtonTextColor)

--- a/GiniPayBusiness/Classes/Core/PaymentReviewViewController.swift
+++ b/GiniPayBusiness/Classes/Core/PaymentReviewViewController.swift
@@ -280,6 +280,10 @@ public final class PaymentReviewViewController: UIViewController, UIGestureRecog
     
     // MARK: - Input fields validation
     
+    @IBAction func textFieldChanged(_ sender: UITextField) {
+        disablePayButtonIfNeeded()
+    }
+    
     fileprivate func validateTextField(_ textField: UITextField) {
         if let fieldIdentifier = TextFieldType(rawValue: textField.tag) {
             switch fieldIdentifier {
@@ -347,11 +351,7 @@ public final class PaymentReviewViewController: UIViewController, UIGestureRecog
     }
     
     fileprivate func disablePayButtonIfNeeded() {
-        if (paymentInputFieldsErrorLabels.allSatisfy { $0.isHidden }) {
-            payButton.isEnabled = (paymentInputFields.allSatisfy {
-                !$0.isReallyEmpty
-            })
-        }
+        payButton.isEnabled = paymentInputFields.allSatisfy { !$0.isReallyEmpty }
     }
 
 
@@ -553,15 +553,6 @@ extension PaymentReviewViewController: UITextFieldDelegate {
         }
     }
     
-    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if let text = textField.text,
-           let textRange = Range(range, in: text) {
-               let updatedText = text.replacingCharacters(in: textRange,
-                                                          with: string).trimmingCharacters(in: .whitespaces)
-               payButton.isEnabled = updatedText.count >= 1
-           }
-        return true
-    }
 }
 // MARK: - UICollectionViewDelegate, UICollectionViewDataSource
 


### PR DESCRIPTION
GiniPayBusiness:
  * GiniCustomButton: defaultBackgroundColor, disabledBackgroundColor properties for normal and disabled states;
  * payButton change the state if at least one symbol in all textfields (whitespaces are trimmed for validation),
  * removed validation on textFieldShouldReturn and textFieldDidEndEditing (PIA-1417)