### PR TITLE
iOS 15 updates

### DIFF
--- a/Example/Example Swift/CaptureSDK/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/CaptureSDK/ComponentAPICoordinator.swift
@@ -468,6 +468,17 @@ extension ComponentAPICoordinator: CameraViewControllerDelegate {
 // MARK: - DocumentPickerCoordinatorDelegate
 
 extension ComponentAPICoordinator: DocumentPickerCoordinatorDelegate {
+    func documentPicker(_ coordinator: DocumentPickerCoordinator, failedToPickDocumentsAt urls: [URL]) {
+        let error = FilePickerError.failedToOpenDocument
+        if coordinator.currentPickerDismissesAutomatically {
+            self.cameraScreen?.showErrorDialog(for: error,
+                                               positiveAction: nil)
+        } else {
+            coordinator.currentPickerViewController?.showErrorDialog(for: error,
+                                                                     positiveAction: nil)
+        }
+    }
+    
     
     func documentPicker(_ coordinator: DocumentPickerCoordinator, didPick documents: [GiniCaptureDocument]) {
         self.validate(documents) { result in
@@ -497,6 +508,8 @@ extension ComponentAPICoordinator: DocumentPickerCoordinatorDelegate {
                         }
                         
                     case .photoLibraryAccessDenied:
+                        break
+                    case .failedToOpenDocument:
                         break
                     }
                 }

--- a/Example/Example Swift/CaptureSDK/ComponentAPICoordinator.swift
+++ b/Example/Example Swift/CaptureSDK/ComponentAPICoordinator.swift
@@ -35,21 +35,34 @@ final class ComponentAPICoordinator: NSObject, Coordinator {
     
     fileprivate lazy var storyboard: UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
     fileprivate lazy var navigationController: UINavigationController = {
-        let navBarViewController = UINavigationController()
-        navBarViewController.navigationBar.barTintColor = self.giniColor
-        navBarViewController.navigationBar.tintColor = .white
+        let navBarViewController = UINavigationController()        
+        navBarViewController.applyStyle(withConfiguration: giniConfiguration)
         navBarViewController.view.backgroundColor = .black
-        
+
         return navBarViewController
     }()
     
     fileprivate lazy var componentAPITabBarController: UITabBarController = {
         let tabBarViewController = UITabBarController()
-        tabBarViewController.tabBar.barTintColor = self.giniColor
-        tabBarViewController.tabBar.tintColor = .white
+        if #available(iOS 15.0, *) {
+            let appearance = UITabBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = self.giniColor
+
+            appearance.stackedLayoutAppearance.normal.iconColor = UIColor.white.withAlphaComponent(0.6)
+            appearance.stackedLayoutAppearance.normal.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white.withAlphaComponent(0.6)]
+            appearance.stackedLayoutAppearance.selected.iconColor = .white
+            appearance.stackedLayoutAppearance.selected.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white]
+
+            tabBarViewController.tabBar.standardAppearance = appearance
+            tabBarViewController.tabBar.scrollEdgeAppearance = tabBarViewController.tabBar.standardAppearance
+        } else {
+            tabBarViewController.tabBar.barTintColor = self.giniColor
+            tabBarViewController.tabBar.tintColor = .white
+            tabBarViewController.tabBar.unselectedItemTintColor = UIColor.white.withAlphaComponent(0.6)
+        }
+
         tabBarViewController.view.backgroundColor = .black
-        
-        tabBarViewController.tabBar.unselectedItemTintColor = UIColor.white.withAlphaComponent(0.6)
         tabBarViewController.tabBar.isHidden = true
 
         return tabBarViewController
@@ -80,6 +93,7 @@ final class ComponentAPICoordinator: NSObject, Coordinator {
          documentService: ComponentAPIDocumentServiceProtocol, giniPayBusiness: GiniPayBusiness) {
         self.pages = pages
         self.giniConfiguration = configuration
+        self.giniConfiguration.onboardingShowAtFirstLaunch = false
         self.documentService = documentService
         self.giniPayBusiness = giniPayBusiness
         super.init()

--- a/Example/Example Swift/CaptureSDK/UIViewController.swift
+++ b/Example/Example Swift/CaptureSDK/UIViewController.swift
@@ -45,6 +45,8 @@ extension UIViewController {
                 confirmActionTitle = NSLocalizedString("ginicapture.camera.mixedarrayspopup.usePhotos",
                                                        bundle: Bundle(for: GiniCapture.self),
                                                        comment: "use photos button text in popup")
+            case .failedToOpenDocument:
+                break
             }
         case let visionError as CustomAnalysisError:
             message = visionError.message

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - GiniCapture (1.0.6):
-    - GiniCapture/Core (= 1.0.6)
-  - GiniCapture/Core (1.0.6)
-  - GiniPayApiLib/DocumentsAPI (1.0.9)
-  - GiniPayApiLib/Pinning (1.0.9):
+  - GiniCapture (1.0.7):
+    - GiniCapture/Core (= 1.0.7)
+  - GiniCapture/Core (1.0.7)
+  - GiniPayApiLib/DocumentsAPI (1.0.10)
+  - GiniPayApiLib/Pinning (1.0.10):
     - GiniPayApiLib/DocumentsAPI
     - TrustKit (~> 1.6)
   - GiniPayBusiness (1.0.8):
@@ -31,8 +31,8 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GiniCapture: e5081746e014243890d97b9d7a72565769131736
-  GiniPayApiLib: 8c668c4c8f4b9a424a950f9cbe6907dca6eb8c78
+  GiniCapture: e010682389214026896786ba714c730e5cb8c0a6
+  GiniPayApiLib: 79595a29253b58ce6f95009f8a334fb7a09e9ef3
   GiniPayBusiness: 0fa40fda7912ba5333f4c2788bf9d594b147865b
   TrustKit: 073855e3adecd317417bda4ac9e9ac54a2e3b9f2
 


### PR DESCRIPTION
iOS 15: Example swift: ComponentAPI: changes needed for using Gini Capture SDK.
 - fixed Navigation bar style;
 - self.giniConfiguration.onboardingShowAtFirstLaunch = false for correctly showing tooltips
 - fixed Tab bar style in case it'll be visible (PIA-1652)
 How to test:
1. checkout Gini Capture SDK branch release_with_ios_15
2. add to Podfile:
pod 'GiniCapture', :path => '~/Documents/ios projects/gini-capture-sdk-ios/'
