### PR TITLE
Pia 1722

### DIFF
--- a/GiniPayBusiness/Classes/Core/GiniPayBusinessConfiguration.swift
+++ b/GiniPayBusiness/Classes/Core/GiniPayBusinessConfiguration.swift
@@ -65,7 +65,17 @@ public final class GiniPayBusinessConfiguration: NSObject {
     /**
      Sets the border width of the payment input fields on the payment review screen
      */
-    @objc public var paymentInputFieldBorderWidth: CGFloat = 1.0
+    @objc public var paymentInputFieldBorderWidth: CGFloat = 0.0
+    
+    /**
+     Sets the border width of the payment input field with selection style on the payment review screen
+     */
+    @objc public var paymentInputFieldSelectionStyleBorderWidth: CGFloat = 1.0
+    
+    /**
+     Sets the border width of the payment input field with error style on the payment review screen
+     */
+    @objc public var paymentInputFieldErrorStyleBorderWidth: CGFloat = 1.0
     
     /**
      Sets the error style color and error text color for the payment input fields on the payment review screen

--- a/GiniPayBusiness/Classes/Core/PaymentReview.storyboard
+++ b/GiniPayBusiness/Classes/Core/PaymentReview.storyboard
@@ -70,7 +70,7 @@
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="5XG-ol-bs7">
                                                         <rect key="frame" x="0.0" y="0.0" width="382" height="52"/>
                                                         <subviews>
-                                                            <textField opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" allowsEditingTextAttributes="YES" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nY6-4z-tMv">
+                                                            <textField opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" allowsEditingTextAttributes="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nY6-4z-tMv">
                                                                 <rect key="frame" x="0.0" y="0.0" width="382" height="40"/>
                                                                 <color key="backgroundColor" red="0.94869893790000004" green="0.95254844429999996" blue="0.96328574420000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <constraints>
@@ -100,7 +100,7 @@
                                                             <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="VVv-3T-au1">
                                                                 <rect key="frame" x="0.0" y="0.0" width="382" height="40"/>
                                                                 <subviews>
-                                                                    <textField opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" allowsEditingTextAttributes="YES" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QXh-1z-x7c">
+                                                                    <textField opaque="NO" tag="2" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" contentHorizontalAlignment="left" contentVerticalAlignment="center" allowsEditingTextAttributes="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QXh-1z-x7c">
                                                                         <rect key="frame" x="0.0" y="0.0" width="276" height="40"/>
                                                                         <color key="backgroundColor" red="0.94869893790000004" green="0.95254844429999996" blue="0.96328574420000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                         <constraints>
@@ -113,7 +113,7 @@
                                                                             <outlet property="delegate" destination="QI6-9C-Fdg" id="m7I-0l-hOv"/>
                                                                         </connections>
                                                                     </textField>
-                                                                    <textField opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" allowsEditingTextAttributes="YES" borderStyle="roundedRect" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="geq-YB-UG4">
+                                                                    <textField opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" allowsEditingTextAttributes="YES" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="geq-YB-UG4">
                                                                         <rect key="frame" x="284" y="0.0" width="98" height="40"/>
                                                                         <color key="backgroundColor" red="0.94869893790000004" green="0.95254844429999996" blue="0.96328574420000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                         <constraints>
@@ -168,7 +168,7 @@
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="g4d-M4-bf3">
                                                         <rect key="frame" x="0.0" y="120" width="382" height="52"/>
                                                         <subviews>
-                                                            <textField opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" allowsEditingTextAttributes="YES" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Q26-IJ-H5m">
+                                                            <textField opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" allowsEditingTextAttributes="YES" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Q26-IJ-H5m">
                                                                 <rect key="frame" x="0.0" y="0.0" width="382" height="40"/>
                                                                 <color key="backgroundColor" red="0.94869893790000004" green="0.95254844429999996" blue="0.96328574420000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <constraints>

--- a/GiniPayBusiness/Classes/Core/PaymentReviewViewController.swift
+++ b/GiniPayBusiness/Classes/Core/PaymentReviewViewController.swift
@@ -224,6 +224,15 @@ public final class PaymentReviewViewController: UIViewController, UIGestureRecog
     // MARK: - Input fields configuration
 
     fileprivate func applyDefaultStyle(_ field: UITextField) {
+        if #available(iOS 13.0, *) {
+            field.borderStyle = .roundedRect
+            field.overrideUserInterfaceStyle = .dark
+        } else {
+            field.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: field.frame.height))
+            field.leftViewMode = .always
+            field.rightView = UIView(frame: CGRect(x: 0, y: 0, width: 10, height: field.frame.height))
+            field.rightViewMode = .always
+        }
         field.layer.cornerRadius = self.giniPayBusinessConfiguration.paymentInputFieldCornerRadius
         field.layer.borderWidth = 0.0
         field.backgroundColor = UIColor.from(giniColor: giniPayBusinessConfiguration.paymentInputFieldBackgroundColor)

--- a/GiniPayBusiness/Classes/Core/PaymentReviewViewController.swift
+++ b/GiniPayBusiness/Classes/Core/PaymentReviewViewController.swift
@@ -234,7 +234,7 @@ public final class PaymentReviewViewController: UIViewController, UIGestureRecog
             field.rightViewMode = .always
         }
         field.layer.cornerRadius = self.giniPayBusinessConfiguration.paymentInputFieldCornerRadius
-        field.layer.borderWidth = 0.0
+        field.layer.borderWidth = giniPayBusinessConfiguration.paymentInputFieldBorderWidth
         field.backgroundColor = UIColor.from(giniColor: giniPayBusinessConfiguration.paymentInputFieldBackgroundColor)
         field.font = giniPayBusinessConfiguration.customFont.regular
         field.textColor = UIColor.from(giniColor: giniPayBusinessConfiguration.paymentInputFieldTextColor)
@@ -247,7 +247,7 @@ public final class PaymentReviewViewController: UIViewController, UIGestureRecog
         UIView.animate(withDuration: 0.3) {
             textField.layer.cornerRadius = self.giniPayBusinessConfiguration.paymentInputFieldCornerRadius
             textField.backgroundColor = UIColor.from(giniColor: self.giniPayBusinessConfiguration.paymentInputFieldBackgroundColor)
-            textField.layer.borderWidth = self.giniPayBusinessConfiguration.paymentInputFieldBorderWidth
+            textField.layer.borderWidth = self.giniPayBusinessConfiguration.paymentInputFieldErrorStyleBorderWidth
             textField.layer.borderColor = self.giniPayBusinessConfiguration.paymentInputFieldErrorStyleColor.cgColor
             textField.layer.masksToBounds = true
         }
@@ -257,7 +257,7 @@ public final class PaymentReviewViewController: UIViewController, UIGestureRecog
         UIView.animate(withDuration: 0.3) {
             textField.layer.cornerRadius = self.giniPayBusinessConfiguration.paymentInputFieldCornerRadius
             textField.backgroundColor = self.giniPayBusinessConfiguration.paymentInputFieldSelectionBackgroundColor
-            textField.layer.borderWidth = self.giniPayBusinessConfiguration.paymentInputFieldBorderWidth
+            textField.layer.borderWidth = self.giniPayBusinessConfiguration.paymentInputFieldSelectionStyleBorderWidth
             textField.layer.borderColor = self.giniPayBusinessConfiguration.paymentInputFieldSelectionStyleColor.cgColor
             textField.layer.masksToBounds = true
         }


### PR DESCRIPTION
Adjusted text field style to apply border:

- GiniPayBusinessConfiguration: introduced properties paymentInputFieldSelectionStyleBorderWidth, paymentInputFieldErrorStyleBorderWidth for setting the border width of the payment input field with selection/error style on the payment review screen (PIA-1722)